### PR TITLE
Create update_datasets.go

### DIFF
--- a/update_datasets.go
+++ b/update_datasets.go
@@ -1,0 +1,30 @@
+package charts
+
+import (
+	"github.com/cnguy/gopherjs-frappe-charts/utils"
+	"github.com/gopherjs/gopherjs/js"
+)
+
+// UpdateValuesArgs is a wrapper that contains the two parameters
+// that chart.update_values(values, labels) requires.
+// https://frappe.github.io/charts/
+// Ctrl + F "update_values"
+type UpdateDatasetsArgs struct {
+	Values [][]*UpdateDataset
+	Labels []string
+}
+
+// UpdateDataSet represents the JS object frappe-chart uses
+// as parameters for chart.update_values(values, labels).
+// e.g. { values: [1, 2, 3, 4] }
+type UpdateDataSet struct {
+	*js.Object
+	Values []interface{} `js:"values"`
+}
+
+// NewUpdateValueSet is a helper to conveniently create an UpdateDataSet.
+func NewUpdateDataSet(values []float64) *UpdateDataSet {
+	new := &UpdateDataSet{Object: js.Global.Get("Object").New()}
+	new.Values = utils.FloatSliceToInterface(values)
+	return new
+}


### PR DESCRIPTION
support aggregation chart update.

usage :

```go

	dataset1 := []*charts.UpdateDataSet{
		charts.NewUpdateDataSet([]float64{25, 40, 30, 35, 8, 52, 17}),
		charts.NewUpdateDataSet([]float64{25, 50, -10, 15, 18, 32, 27}),
		charts.NewUpdateDataSet([]float64{25, 40, 30, 35, 8, 52, 17}),
		charts.NewUpdateDataSet([]float64{25, 50, -10, 15, 18, 32, 27}),
	}
	dataset2 := []*charts.UpdateDataSet{
		charts.NewUpdateDataSet([]float64{25, 40, 30, 35, 8, 52, 17}),
		charts.NewUpdateDataSet([]float64{25, 50, -10, 15, 18, 32, 27}),
		charts.NewUpdateDataSet([]float64{25, 40, 30, 35, 8, 52, 17}),
		charts.NewUpdateDataSet([]float64{25, 50, -10, 15, 18, 32, 27}),
	}

	moreBarchartDatasets := [][]*charts.UpdateDataSet{
		dataset1,
		dataset2,
	}

	mainChart.AddDataSelectListener(func(event*charts.DataSelectEvent){
		updateDataset := &charts.UpdateDatasetsArgs{
			Values: [][]*charts.UpdateDataSet{moreBarchartDatasets [event.Index]},
			Labels: barchart.Labels,
		}
		barchart.UpdateDatasets(updateDataset)
	})
```